### PR TITLE
fix(angular-v17-anguMAT): fontawesome removed to see if netlify goes through

### DIFF
--- a/angular-v17-AnguMAT/package-lock.json
+++ b/angular-v17-AnguMAT/package-lock.json
@@ -20,7 +20,6 @@
         "@angular/platform-server": "^17.2.0",
         "@angular/router": "^17.2.0",
         "@angular/ssr": "^17.2.0",
-        "@fortawesome/fontawesome-free": "^6.5.1",
         "apollo-angular": "^6.0.0",
         "express": "^4.18.2",
         "rxjs": "~7.8.0",

--- a/angular-v17-AnguMAT/package.json
+++ b/angular-v17-AnguMAT/package.json
@@ -25,7 +25,6 @@
     "@angular/router": "^17.2.0",
     "@angular/ssr": "^17.2.0",
     "apollo-angular": "^6.0.0",
-    "@fortawesome/fontawesome-free": "^6.5.1",
     "express": "^4.18.2",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",

--- a/angular-v17-AnguMAT/src/index.html
+++ b/angular-v17-AnguMAT/src/index.html
@@ -8,6 +8,8 @@
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0" />
+  <script src="https://kit.fontawesome.com/1f707df0d7.js" crossorigin="anonymous"></script>
 </head>
 <body class="mat-typography">
   <app-root></app-root>


### PR DESCRIPTION
# Angular App version

- [ ] `angular-v17` - has no UI libraries
- [x] `angular-v17-modMAT` - modules and Angular Material
- [ ] `angular-v17-AnguMAT` - has Angular Material
- [ ] `angular-v17-PrimeNG` - has PrimeNG

## This PR Closes Issue 
closes #

## Description

## What type of PR is this? (check all applicable)
- [ ] 🅰️ Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Mobile & Desktop Screenshots/Recordings
[Attach screenshots or recordings if applicable]

## Steps to QA

## Added to documentation?
- [ ] 📜 README.md
- [x] 🙅 no documentation needed

## [Optional] Post-deployment tasks
[Specify any post-deployment tasks that need to be performed]

## [Optional] What gif best describes this PR or how it makes you feel? 
[Embed gif or describe the feeling in plain text]
