### PR TITLE
fix(angular-v17-primeng): adjust image aspect ratio in post cards

### DIFF
--- a/angular-v17-PrimeNG/src/styles.scss
+++ b/angular-v17-PrimeNG/src/styles.scss
@@ -22,4 +22,5 @@ a {
   overflow: hidden;
   border-top-left-radius: 6px;
   border-top-right-radius: 6px;
+  object-fit: cover;
 }


### PR DESCRIPTION
# Angular App version

- [ ] `angular-v17` - has no UI libraries
- [ ] `angular-v17-modMAT` - modules and Angular Material
- [ ] `angular-v17-AnguMAT` - has Angular Material
- [x] `angular-v17-PrimeNG` - has PrimeNG

## This PR Closes Issue 
closes #226 

## Description

## What type of PR is this? (check all applicable)
- [ ] 🅰️ Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [x] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Mobile & Desktop Screenshots/Recordings
[Attach screenshots or recordings if applicable]

## Steps to QA

## Added to documentation?
- [ ] 📜 README.md
- [x] 🙅 no documentation needed

## [Optional] Post-deployment tasks
[Specify any post-deployment tasks that need to be performed]

## [Optional] What gif best describes this PR or how it makes you feel? 
[Embed gif or describe the feeling in plain text]
