### PR TITLE
feat(angular-v17-primeng): match the bg color of the cards to the header in light mode

### DIFF
--- a/angular-v17-PrimeNG/angular.json
+++ b/angular-v17-PrimeNG/angular.json
@@ -32,12 +32,12 @@
             "styles": [
               "src/styles.scss",
               {
-                "input": "primeng/resources/themes/lara-dark-blue/theme.css",
+                "input": "src/assets/themes/dark.scss",
                 "bundleName": "dark",
                 "inject": false
               },
               {
-                "input": "primeng/resources/themes/lara-light-blue/theme.css",
+                "input": "src/assets/themes/light.scss",
                 "bundleName": "light",
                 "inject": false
               },

--- a/angular-v17-PrimeNG/src/assets/themes/light.scss
+++ b/angular-v17-PrimeNG/src/assets/themes/light.scss
@@ -1,1 +1,5 @@
 @import "primeng/resources/themes/lara-light-blue/theme.css";
+
+.p-card {
+  background-color: var(--surface-50);
+}


### PR DESCRIPTION
# Angular App version

- [ ] `angular-v17` - has no UI libraries
- [ ] `angular-v17-modMAT` - modules and Angular Material
- [ ] `angular-v17-AnguMAT` - has Angular Material
- [x] `angular-v17-PrimeNG` - has PrimeNG

## This PR Closes Issue 
closes #225 

## Description

## What type of PR is this? (check all applicable)
- [ ] 🅰️ Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [x] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Mobile & Desktop Screenshots/Recordings
[Attach screenshots or recordings if applicable]

## Steps to QA

## Added to documentation?
- [ ] 📜 README.md
- [x] 🙅 no documentation needed

## [Optional] Post-deployment tasks
[Specify any post-deployment tasks that need to be performed]

## [Optional] What gif best describes this PR or how it makes you feel? 
[Embed gif or describe the feeling in plain text]
