### PR TITLE
fix(header-v17-modemat): home redirect link syntax

### DIFF
--- a/angular-v17-modMAT/src/app/components/header/header.component.html
+++ b/angular-v17-modMAT/src/app/components/header/header.component.html
@@ -1,6 +1,6 @@
 <mat-toolbar>
   <mat-toolbar-row>
-    <a routerLink="/" class="logo">
+    <a [routerLink]="['/']" class="logo">
       <img src="../../../assets/images/angular-headless-hashnode-logo.jpg" alt="logo" />
       <h1>{{ blogName }}</h1>
     </a>


### PR DESCRIPTION
# Angular App version

- [ ] `angular-v17` - has no UI libraries
- [x] `angular-v17-modMAT` - modules and Angular Material
- [ ] `angular-v17-AnguMAT` - has Angular Material
- [ ] `angular-v17-PrimeNG` - has PrimeNG

## This PR Closes Issue 
closes #245 

## Description

## What type of PR is this? (check all applicable)
- [ ] 🅰️ Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Mobile & Desktop Screenshots/Recordings
[Attach screenshots or recordings if applicable]

## Steps to QA

## Added to documentation?
- [ ] 📜 README.md
- [x] 🙅 no documentation needed

## [Optional] Post-deployment tasks
[Specify any post-deployment tasks that need to be performed]

## [Optional] What gif best describes this PR or how it makes you feel? 
[Embed gif or describe the feeling in plain text]
