### PR TITLE
fix(header-v17-primeNG): Add a redirect to home from logo in header v17 PrimeNG

### DIFF
--- a/angular-v17-PrimeNG/src/app/components/header/header.component.html
+++ b/angular-v17-PrimeNG/src/app/components/header/header.component.html
@@ -1,6 +1,6 @@
 <p-toolbar>
   <div class="toolbar-row">
-    <a class="logo" href="">
+    <a class="logo" routerLink="/">
       <img src="../../../assets/images/angular-headless-hashnode-logo.jpg" alt="logo" />
       <h1>{{ blogName }}</h1>
     </a>


### PR DESCRIPTION
# Angular App version

- [ ] `angular-v17` - has no UI libraries
- [ ] `angular-v17-modMAT` - modules and Angular Material
- [ ] `angular-v17-AnguMAT` - has Angular Material
- [x] `angular-v17-PrimeNG` - has PrimeNG

## This PR Closes Issue 
closes #259 

## Description

## What type of PR is this? (check all applicable)
- [ ] 🅰️ Feature
- [ x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Added to documentation?
- [ ] 📜 README.md
- [x ] 🙅 no documentation needed