### PR TITLE
fix(angular-v17-primeng): fix the overflowing of the post card title

### DIFF
--- a/angular-v17-PrimeNG/src/styles.scss
+++ b/angular-v17-PrimeNG/src/styles.scss
@@ -16,11 +16,14 @@ a {
     transition: all 0.3s ease-in-out;
   }
 
+  .p-card {
+    height: 100%;
+  }
+
   .p-card-title {
     font-size: 1.2rem;
     line-height: 1.7rem;
     font-weight: 500;
-    height: 4.3rem;
   }
 
   .p-card-content {


### PR DESCRIPTION
# Angular App version

- [ ] `angular-v17` - has no UI libraries
- [ ] `angular-v17-modMAT` - modules and Angular Material
- [ ] `angular-v17-AnguMAT` - has Angular Material
- [x] `angular-v17-PrimeNG` - has PrimeNG

## This PR Closes Issue 
closes #327 

## Description

## What type of PR is this? (check all applicable)
- [ ] 🅰️ Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [x] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Mobile & Desktop Screenshots/Recordings
[Attach screenshots or recordings if applicable]

## Steps to QA

## Added to documentation?
- [ ] 📜 README.md
- [x] 🙅 no documentation needed

## [Optional] Post-deployment tasks
[Specify any post-deployment tasks that need to be performed]

## [Optional] What gif best describes this PR or how it makes you feel? 
[Embed gif or describe the feeling in plain text]
