### PR TITLE
feat(v17): logo image, site favicon, author queries, interface, method

### DIFF
--- a/angular-v17/src/app/components/header/header.component.html
+++ b/angular-v17/src/app/components/header/header.component.html
@@ -1,7 +1,7 @@
 <div class="toolbar" role="banner">
   <div class="toolbar-row">
     <a routerLink="/" class="logo">
-      <img src="../../../assets/images/angular-headless-hashnode-logo.jpg" alt="logo" />
+      <img src="{{blogImage}}" alt="logo" />
       <h1>{{ blogName }}</h1>
     </a>
     <div class="theme-control">

--- a/angular-v17/src/app/components/header/header.component.ts
+++ b/angular-v17/src/app/components/header/header.component.ts
@@ -40,6 +40,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
           this.siteFavicon.href = this.blogInfo.favicon;
         } else {
           this.blogImage = '/assets/images/angular-headless-hashnode-logo.jpg'
+          this.siteFavicon.href = 'favicon.ico';
         }
 
         if (!this.blogInfo.isTeam) {
@@ -51,6 +52,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
               this.siteFavicon.href = data.profilePicture;
             } else {
               this.blogImage = '/assets/images/angular-headless-hashnode-logo.jpg'
+              this.siteFavicon.href = 'favicon.ico';
             }
           });
         }

--- a/angular-v17/src/app/components/header/header.component.ts
+++ b/angular-v17/src/app/components/header/header.component.ts
@@ -39,11 +39,19 @@ export class HeaderComponent implements OnInit, OnDestroy {
           this.blogImage = this.blogInfo.favicon;
           this.siteFavicon.href = this.blogInfo.favicon;
         } else {
+          this.blogImage = '/assets/images/angular-headless-hashnode-logo.jpg'
+        }
+
+        if (!this.blogInfo.isTeam) {
           this.blogService
           .getAuthorInfo()
           .subscribe((data) => {
             this.blogImage = data.profilePicture;
-            this.siteFavicon.href = data.profilePicture;
+            if (data.profilePicture) {
+              this.siteFavicon.href = data.profilePicture;
+            } else {
+              this.blogImage = '/assets/images/angular-headless-hashnode-logo.jpg'
+            }
           });
         }
         const { __typename, ...links } = data.links;

--- a/angular-v17/src/app/graphql.operations.ts
+++ b/angular-v17/src/app/graphql.operations.ts
@@ -5,8 +5,9 @@ export const BLOG_HOST = "angular-headless.hashnode.dev";
 export const GET_BLOG_INFO = gql`
 query Publication {
   publication(host: "${BLOG_HOST}") {
-    id,
-    title,
+    id
+    title
+    isTeam
     links {
       twitter
       instagram
@@ -18,11 +19,30 @@ query Publication {
       linkedin
       mastodon
     }
-    followersCount,
-    url,
-    favicon,
+    followersCount
+    url
+    favicon
+  }
+}
+`;
+
+export const GET_AUTHOR_INFO = gql`
+query Publication {
+  publication(host: "${BLOG_HOST}") {
     author {
-    profilePicture
+      username
+      profilePicture
+      socialMediaLinks {
+      	__typename
+        facebook
+        github
+        instagram
+        linkedin
+        stackoverflow
+        twitter
+        website
+        youtube
+      }
     }
   }
 }

--- a/angular-v17/src/app/models/blog-info.ts
+++ b/angular-v17/src/app/models/blog-info.ts
@@ -1,5 +1,4 @@
 export interface BlogInfo {
-  author: any;
   id: string;
   title: string;
   isTeam?: boolean;

--- a/angular-v17/src/app/models/blog-info.ts
+++ b/angular-v17/src/app/models/blog-info.ts
@@ -1,14 +1,15 @@
 export interface BlogInfo {
+  author: any;
   id: string;
   title: string;
-  links: SocialLinks;
+  isTeam?: boolean;
+  links: BlogLinks;
   followersCount: number;
   url: string;
   favicon?: string;
-  author?:Author;
 }
 
-export type SocialLinks = {
+export type BlogLinks = {
   __typename?: string;
   twitter: string;
   instagram: string;
@@ -20,7 +21,3 @@ export type SocialLinks = {
   linkedin: string;
   mastodon: string;
 };
-
-export interface Author {
-  profilePicture?: string;
-}

--- a/angular-v17/src/app/models/post.ts
+++ b/angular-v17/src/app/models/post.ts
@@ -29,7 +29,13 @@ export interface Author {
 }
 
 export interface SocialMediaLinks {
+  facebook: string;
+  github: string;
+  instagram: string;
+  linkedin: string;
+  stackoverflow: string;
   twitter: string;
+  website: string;
   youtube: string;
 }
 

--- a/angular-v17/src/app/services/blog.service.ts
+++ b/angular-v17/src/app/services/blog.service.ts
@@ -1,8 +1,8 @@
 import { Injectable } from '@angular/core';
 import { Apollo } from "apollo-angular";
 import { Observable, map } from 'rxjs';
-import { GET_BLOG_INFO, GET_POSTS, GET_POSTS_IN_SERIES, GET_SERIES_LIST, GET_SINGLE_POST } from '../graphql.operations';
-import { Post, SeriesList } from '../models/post';
+import { GET_AUTHOR_INFO, GET_BLOG_INFO, GET_POSTS, GET_POSTS_IN_SERIES, GET_SERIES_LIST, GET_SINGLE_POST } from '../graphql.operations';
+import { Author, Post, SeriesList } from '../models/post';
 import { BlogInfo } from '../models/blog-info';
 
 @Injectable({
@@ -18,6 +18,14 @@ export class BlogService {
       query: GET_BLOG_INFO,
     })
     .valueChanges.pipe(map(({ data }) => data.publication));
+  }
+
+  getAuthorInfo(): Observable<Author> {
+    return this.apollo
+    .watchQuery<any>({
+      query: GET_AUTHOR_INFO,
+    })
+    .valueChanges.pipe(map(({ data }) => data.publication.author));
   }
 
   getPosts(): Observable<Post[]> {


### PR DESCRIPTION
# Angular App version

- [x] `angular-v17` - has no UI libraries
- [ ] `angular-v17-modMAT` - modules and Angular Material
- [ ] `angular-v17-AnguMAT` - has Angular Material
- [ ] `angular-v17-PrimeNG` - has PrimeNG

## This PR Closes Issue 
closes #280 
closes #338 
closes #340 

## Description

Blog image in header was connected to the actual blog image, via graphql query and checks to see if it is a team blog and if favicon exists - `favicon` has a multi use in Hashnode and it is is the the query when it is a team blog.
A conditional check added to set the blog logo to a author image if it is not a team blog, bot checks go to default image if there are no available images to use (so that the site doesn't stay image-less) 
Interfaces are separated, methods & queries adjusted - more info in each issue

## What type of PR is this? (check all applicable)
- [x] 🅰️ Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Mobile & Desktop Screenshots/Recordings
[Attach screenshots or recordings if applicable]

## Steps to QA

## Added to documentation?
- [ ] 📜 README.md
- [x] 🙅 no documentation needed

